### PR TITLE
Add support for retrieving premium account transactions

### DIFF
--- a/src/API/Account.php
+++ b/src/API/Account.php
@@ -72,4 +72,24 @@ class Account {
         return $json;
     }
 
+    /**
+     * Retrieve premium account transactions.
+     * @param string $accountId
+     *
+     * @return array
+     */
+    public function getPremiumAccountTransactions(?string $country = null, ?string $dateFrom = null, ?string $dateTo = null): array
+    {
+        $params = [
+            'query' => []
+        ];
+
+        if ($country)  $params['query']['country']   = $country;
+        if ($dateFrom) $params['query']['date_from'] = $dateFrom;
+        if ($dateTo)   $params['query']['date_to']   = $dateTo;
+
+        $response = $this->requestHandler->get("accounts/premium/{$this->accountId}/transactions/", $params);
+        $json = json_decode($response->getBody()->getContents(), true);
+        return $json;
+    }
 }

--- a/src/API/Account.php
+++ b/src/API/Account.php
@@ -74,7 +74,9 @@ class Account {
 
     /**
      * Retrieve premium account transactions.
-     * @param string $accountId
+     * @param ?string $country
+     * @param ?string $dateFrom
+     * @param ?string $dateTo
      *
      * @return array
      */


### PR DESCRIPTION
## Proposed Changes
  * Add support for premium accounts

## Additional Info
Currently the client doesn't support the premium products of Nordigen. Added support for that.

I've taken on from where the previous [Premium Support PR](https://github.com/nordigen/nordigen-php/pull/8) has staled. Also according to Nordigen [documentation](https://nordigen.com/en/docs/account-information/integration/parameters-and-responses/#/) it is only the transactions endpoint that supports premium accounts - thus this is the only one I've added in this PR.
