### PR TITLE
Add support for all parameters in InitSession function

### DIFF
--- a/src/API/NordigenClient.php
+++ b/src/API/NordigenClient.php
@@ -39,28 +39,34 @@ class NordigenClient
 
 
     /**
-        * Perform all the necessary steps in order to retrieve the URL for user authentication. <br>
-        * A new End-User agreement and requisition will be created.
-        *
-        * The result will be an array containing the URL for user authentication and the IDs of the
-        * newly created requisition and End-user agreement.
-        * @param string $institutionIdentifier ID of the Institution.
-        * @param int $maxHistoricalDays Maximum number of days of transaction data to retrieve.
-        * @param string $endUserId The ID of the End-user in the client's system.
-        * @param string $reference
-        * @param string $redirect
-        * @param AccessScope[] $accessScope
-        * @param string|null $userLanguage
-        *
-        * @return array
-    */
+     * Perform all the necessary steps in order to retrieve the URL for user authentication. <br>
+     * A new End-User agreement and requisition will be created.
+     *
+     * The result will be an array containing the URL for user authentication and the IDs of the
+     * newly created requisition and End-user agreement.
+     * @param string $institutionIdentifier ID of the Institution.
+     * @param int $maxHistoricalDays Maximum number of days of transaction data to retrieve.
+     * @param string $endUserId The ID of the End-user in the client's system.
+     * @param string $reference Additional ID to identify the End-user. This value will be appended to the redirect.
+     * @param string $redirect The URI where the End-user will be redirected to after authentication.
+     * @param AccessScope[] $accessScope The requested access scope. All by default. See Enums\AccessScope for possible values.
+     * @param string|null $userLanguage Language to use in views. Two-letter country code (ISO 639-1).
+     * @param string|null $ssn SSN (social security number) field to verify ownership of the account.
+     * @param bool|null $accountSelection Option to enable account selection view for the end user.
+     * @param bool|null $redirectImmediate Option to enable redirect back to the client after account list received
+     *
+     * @return array
+     */
     public function initSession(
         string  $institutionIdentifier,
         string  $redirect,
         int     $maxHistoricalDays = 90,
         ?string $reference = null,
         ?array $accessScopes = ['details', 'balances', 'transactions'],
-        ?string $userLanguage = null
+        ?string $userLanguage = null,
+        ?string $ssn = null,
+        ?bool $accountSelection = null,
+        ?bool $redirectImmediate = false
     ): array
     {
         $endUserAgreement = $this->endUserAgreement->createEndUserAgreement(
@@ -73,7 +79,10 @@ class NordigenClient
             $institutionIdentifier,
             $endUserAgreement["id"],
             $reference,
-            $userLanguage
+            $userLanguage,
+            $ssn,
+            $accountSelection,
+            $redirectImmediate
         );
         $result = [
             'link' => $requisition["link"],

--- a/src/API/NordigenClient.php
+++ b/src/API/NordigenClient.php
@@ -45,7 +45,8 @@ class NordigenClient
      * The result will be an array containing the URL for user authentication and the IDs of the
      * newly created requisition and End-user agreement.
      * @param string $institutionIdentifier ID of the Institution.
-     * @param int $maxHistoricalDays Maximum number of days of transaction data to retrieve.
+     * @param int $maxHistoricalDays Maximum number of days of transaction data to retrieve. 90 by default.
+     * @param int $accessValidForDays How long access to the end-user's account will be available. 90 days by default.
      * @param string $endUserId The ID of the End-user in the client's system.
      * @param string $reference Additional ID to identify the End-user. This value will be appended to the redirect.
      * @param string $redirect The URI where the End-user will be redirected to after authentication.
@@ -61,6 +62,7 @@ class NordigenClient
         string  $institutionIdentifier,
         string  $redirect,
         int     $maxHistoricalDays = 90,
+        int     $accessValidForDays = 90,
         ?string $reference = null,
         ?array $accessScopes = ['details', 'balances', 'transactions'],
         ?string $userLanguage = null,
@@ -72,7 +74,8 @@ class NordigenClient
         $endUserAgreement = $this->endUserAgreement->createEndUserAgreement(
             $institutionIdentifier,
             $accessScopes,
-            $maxHistoricalDays
+            $maxHistoricalDays,
+            $accessValidForDays
         );
         $requisition = $this->requisition->createRequisition(
             $redirect,

--- a/src/API/NordigenClient.php
+++ b/src/API/NordigenClient.php
@@ -66,7 +66,7 @@ class NordigenClient
         ?string $userLanguage = null,
         ?string $ssn = null,
         ?bool $accountSelection = null,
-        ?bool $redirectImmediate = false
+        ?bool $redirectImmediate = null
     ): array
     {
         $endUserAgreement = $this->endUserAgreement->createEndUserAgreement(


### PR DESCRIPTION
## Proposed Changes
  * Add support for **ALL** parameters in `initSession` function

## Additional Info
The `initSession` function does not support all possible parameters that the `createEndUserAgreement` and `createRequisition` support. This did not allow me to set the `redirectImmediate` parameter when calling the init function.

I went ahead and added all other missing parameters too and updated the functions description.
