### PR TITLE
Replace cdn URLs

### DIFF
--- a/example/resources/views/home.blade.php
+++ b/example/resources/views/home.blade.php
@@ -31,7 +31,7 @@
     <script>
         const config = {
             redirectUrl: 'https://www.nordigen.com',
-            logoUrl: 'https://cdn.nordigen.com/ais/Nordigen_Logo_Black.svg',
+            logoUrl: 'https://cdn-logos.gocardless.com/ais/Nordigen_Logo_Black.svg',
             countryFilter: true,
 			styles: {
 				fontFamily: 'https://fonts.googleapis.com/css2?family=Roboto&display=swap',

--- a/tests/UnitTests/NordigenIntegrationTest.php
+++ b/tests/UnitTests/NordigenIntegrationTest.php
@@ -81,7 +81,7 @@ class NordigenIntegrationTest extends TestCase
                 "countries": [
                     "DE"
                 ],
-                "logo": "https://cdn.nordigen.com/ais/ABNAMRO_FTSBDEFAXXX.png"
+                "logo": "https://cdn-logos.gocardless.com/ais/ABNAMRO_FTSBDEFAXXX.png"
             }';
         $response = new Response(200, [], $responseBody);
         self::$mock->append($response);
@@ -104,7 +104,7 @@ class NordigenIntegrationTest extends TestCase
                     "countries": [
                         "DE"
                     ],
-                    "logo": "https://cdn.nordigen.com/ais/ABNAMRO_FTSBDEFAXXX.png"
+                    "logo": "https://cdn-logos.gocardless.com/ais/ABNAMRO_FTSBDEFAXXX.png"
                 },
                 {
                     "id": "SOMETHING",


### PR DESCRIPTION
Updated `cdn.nordigen.com` to `cdn-logos.gocardless.com`, as nordigen.com domain will be deprecated.