### PR TITLE
PHP 8.3 fixed dynamic property creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,6 +271,9 @@ tmtags
 !.vscode/extensions.json
 *.code-workspace
 
+## JetBrains
+.idea/
+
 # Local History for Visual Studio Code
 .history/
 

--- a/src/API/Account.php
+++ b/src/API/Account.php
@@ -7,6 +7,7 @@ use Nordigen\NordigenPHP\API\RequestHandler;
 class Account {
 
     private RequestHandler $requestHandler;
+    private string $accountId;
 
     public function __construct(RequestHandler $requestHandler, string $accountId) {
         $this->requestHandler = $requestHandler;

--- a/src/API/RequestHandler.php
+++ b/src/API/RequestHandler.php
@@ -11,6 +11,7 @@ class RequestHandler
     use RequestHandlerTrait;
 
     private string $accessToken;
+    private array $authentication;
 
     public function __construct(string $baseUri, string $secretId, string $secretKey, ?ClientInterface $client)
     {


### PR DESCRIPTION
## Related Issue
Dynamic creation of properties is deprecated for new versions of PHP.

## Proposed Changes
  * src/API/Account.php - declaration of private string $accountId
  * src/API/RequestHandler.php - declaration of private array $authentication

